### PR TITLE
BUG: ensure transform + trajectory docs are rendered

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -13,8 +13,9 @@
 import os
 import sys
 from pathlib import Path
+import ropy.transform as rtf
 
-sys.path.insert(0, Path(__file__).parents[2])
+# sys.path.insert(0, Path(__file__).parents[2])
 
 
 # -- Project information -----------------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -13,7 +13,7 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("..\\..\\ropy"))
+sys.path.insert(0, os.path.abspath("../.."))
 
 
 # -- Project information -----------------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -12,8 +12,9 @@
 #
 import os
 import sys
+from pathlib import Path
 
-sys.path.insert(0, os.path.abspath("../.."))
+sys.path.insert(0, Path(__file__).parents[2])
 
 
 # -- Project information -----------------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -10,10 +10,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
-import sys
-from pathlib import Path
-import ropy.transform as rtf
+# import os
+# import sys
+# from pathlib import Path
 
 # sys.path.insert(0, Path(__file__).parents[2])
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,14 +12,14 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    numpy == 1.20.0
+    numpy == 1.20.3
     scipy == 1.6.1
 
 [options.extras_require]
 ignition =
     pyzmq == 22.0.3
-    betterproto
-    psutil
+    betterproto == 1.2.5
+    psutil == 5.8.0
 docs = 
     sphinx == 3.5.3
     numpydoc == 1.1.0
@@ -27,11 +27,11 @@ docs =
     matplotlib == 3.3.4
     pydata-sphinx-theme == 0.6.3
 linting = 
-    flake8
-    black
+    flake8 == 3.9.0
+    black == 20.8b1
 testing = 
-    pytest
-    coverage[toml]
+    pytest == 6.2.2
+    coverage[toml] == 5.5
 
 [flake8]
 exclude = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    numpy == 1.19.5
+    numpy == 1.20.0
     scipy == 1.6.1
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,12 +12,12 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    numpy >= 1.19.5
-    scipy >= 1.6.1
+    numpy == 1.19.5
+    scipy == 1.6.1
 
 [options.extras_require]
 ignition =
-    pyzmq >= 22.0.3
+    pyzmq == 22.0.3
     betterproto
     psutil
 docs = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,11 +21,11 @@ ignition =
     betterproto
     psutil
 docs = 
-    sphinx
-    numpydoc
-    sphinx-autodoc-typehints
-    matplotlib
-    pydata-sphinx-theme
+    sphinx == 3.5.3
+    numpydoc == 1.1.0
+    sphinx-autodoc-typehints == 1.11.1
+    matplotlib == 3.3.4
+    pydata-sphinx-theme == 0.6.3
 linting = 
     flake8
     black

--- a/tests/ignition/test_subscriber.py
+++ b/tests/ignition/test_subscriber.py
@@ -12,7 +12,7 @@ def ign_instance():
     gazebo = subprocess.Popen(["ign", "gazebo", "shapes.sdf", "-s"])
 
     # wait for gazebo to start
-    time.sleep(3)
+    time.sleep(5)
 
     yield
 


### PR DESCRIPTION
locally the docs build fine, but on RTD the sub-modules `ropy.transform` and `ropy.trajectory` are not rendered. This PR investigates and fixes this issue.