### PR TITLE
FEAT: element constructor overload

### DIFF
--- a/skbot/ignition/sdformat/sdformat.py
+++ b/skbot/ignition/sdformat/sdformat.py
@@ -113,15 +113,14 @@ def loads(
 
     """
 
-    # Disabled until xsData upgrades to the next version
-    # if custom_constructor is None:
-    #     custom_constructor = dict()
+    if custom_constructor is None:
+        custom_constructor = dict()
 
-    # def custom_class_factory(clazz, params):
-    #     if clazz in custom_constructor:
-    #         return custom_constructor[clazz](**params)
+    def custom_class_factory(clazz, params):
+        if clazz in custom_constructor:
+            return custom_constructor[clazz](**params)
 
-    #     return clazz(**params)
+        return clazz(**params)
 
     if version is None:
         version = get_version(sdf)
@@ -138,11 +137,11 @@ def loads(
 
     bindings = importlib.import_module(binding_location, __name__)
 
-    # Disabled until xsData upgrades to the next version
-    # sdf_parser = XmlParser(
-    #     ParserConfig(class_factory=custom_class_factory), context=xml_ctx
-    # )
-    sdf_parser = XmlParser(ParserConfig(), xml_ctx, handler=handler_class)
+    sdf_parser = XmlParser(
+        ParserConfig(class_factory=custom_class_factory),
+        context=xml_ctx,
+        handler=handler_class,
+    )
 
     try:
         sdf_parser.from_string(sdf, bindings.Sdf)

--- a/tests/ignition/test_sdformat.py
+++ b/tests/ignition/test_sdformat.py
@@ -28,7 +28,6 @@ def test_invalid_parsing_xml_etree(invalid_sdf_string):
         ign.sdformat.loads(invalid_sdf_string, handler="XmlEventHandler")
 
 
-@pytest.mark.skip(reason="Currently disabled.")
 def test_custom_constructor(valid_sdf_string):
     @dataclass
     class NewPose:


### PR DESCRIPTION
Was unavailable prior to xsdata 21.8, but can now be enabled because we upgraded our dependencies.